### PR TITLE
Add documentation for resend invitation email

### DIFF
--- a/users.admin.invite.md
+++ b/users.admin.invite.md
@@ -10,6 +10,7 @@ email|john.doe@email.com|Required|Email address of the new user
 channels|C1234567890|Optional|Comma-separated list of channel names or IDs which the new user will auto-join
 first_name|John|Optional|Prefilled input for the "First name" field on the "new user registration" page.
 last_name|Doe|Optional|Prefilled input for the "Last name" field on the "new user registration" page.
+resend|true|Optional|Resend the invitation email if the user has already been invited and the email was sent some time ago.
 
 ##Response
 You will receive a standard Slack API response in JSON as described [here](https://api.slack.com/web#basics). For example if successful you get:
@@ -24,4 +25,5 @@ Error|Description
 --------|-------
 `already_invited`|User has already received an email invitation
 `already_in_team`|User is already part of the team
+`sent_recently`|When using resend=true, the email has been sent recently already
 tbd


### PR DESCRIPTION
Hi there!

Just getting to know the Slack API a bit better to answer an issue on a project I am just starting with :)

Say someone wants to resend the email whenever an already invited user ask for an invitation again (https://github.com/vluzrmos/lumen-slackin/issues/9), here's the documentation that helps the use case.