### PR TITLE
Provide details on channels for users.admin.invite

### DIFF
--- a/users.admin.invite.md
+++ b/users.admin.invite.md
@@ -7,7 +7,7 @@ Argument|Example|Required|Description
 --------|-------|--------|-----------
 token|xxxx-xxxxxxxxx-xxxx|Required|Authentication token (Requires scope: `'client'`)
 email|john.doe@email.com|Required|Email address of the new user
-channels|C1234567890|Optional|Comma-separated list of channel names or IDs which the new user will auto-join
+channels|C1234567890|Optional|Comma-separated list of channel IDs (not names!) which the new user will auto-join
 first_name|John|Optional|Prefilled input for the "First name" field on the "new user registration" page.
 last_name|Doe|Optional|Prefilled input for the "Last name" field on the "new user registration" page.
 resend|true|Optional|Resend the invitation email if the user has already been invited and the email was sent some time ago.
@@ -25,6 +25,7 @@ Error|Description
 --------|-------
 `already_invited`|User has already received an email invitation
 `already_in_team`|User is already part of the team
+`channel_not_found`|Provided channel ID does not match a real channel
 `sent_recently`|When using resend=true, the email has been sent recently already
 `user_disabled`|User account has been deactivated
 `missing_scope`|Using an access_token not authorized for `'client'` scope


### PR DESCRIPTION
Channel names do not appear to be allowed, since passing in something like `general` or `general,random` fails miserably with the channels not being found - instead, IDs seem to be expected there. Oh, and there is a specific error code for that case.