### PR TITLE
Fix markdown formatting on users.admin.setInactive

### DIFF
--- a/users.admin.setInactive.md
+++ b/users.admin.setInactive.md
@@ -1,7 +1,9 @@
 # users.admin.setInactive
 This method disables a user. A disabled user can no longer log into a Slack team.
 Note: This method does not work on free tier.
-##Arguments
+
+## Arguments
+
 This method has the URL `https://slack.com/api/users.admin.setInactive` and follows the [Slack Web API calling conventions](https://api.slack.com/web#basics).
 
 Argument|Example|Required|Description
@@ -9,7 +11,8 @@ Argument|Example|Required|Description
 token|xxxx-xxxxxxxxx-xxxx|Required|Authentication token (Requires scope: ??)
 user|U1234567890|Required|ID of the user to be disabled
 
-##Response
+## Response
+
 You will receive a standard Slack API response in JSON as described [here](https://api.slack.com/web#basics). For example if successful you get:
 
 ```json
@@ -17,7 +20,8 @@ You will receive a standard Slack API response in JSON as described [here](https
 "ok": true
 }
 ```
-##Errors & Warnings
+## Errors & Warnings
+
 Error|Description
 --------|-------
 paid_only|Error message when used with a free Slack team


### PR DESCRIPTION
Github was not a fan of the prior formatting and put the title and body on the same line, and didn't actually make the body a header.