### PR TITLE
Add curl example for chat.command

### DIFF
--- a/chat.command.md
+++ b/chat.command.md
@@ -11,6 +11,11 @@ Argument|Example|Required|Description
 `command`|`/who`|Required|Slash command to be executed. Leading backslash is required.
 `text`|`xxxx-xxxxxxxxx-xxxx`|Optional|Additional parameters provided to the slash command
 
+Example usage with [curl](https://curl.haxx.se/) and the [Slack GitHub app](https://slack.github.com/):
+
+    curl --silent --request GET \
+    'https://slack.com/api/chat.command?token=123&channel=CHANNEL_ID&command=/github&text=subscribe%20owner/repo%20branches'
+
 ## Response
 You will receive a response in JSON indicating if the command has been executed successfully or not with the `ok` variable. 
 For some internal commands (e.g. `/who`) the response of the slash command will be provided in the `response` variable. For most slash commands  the response will instead be produced in the channel on Slack.


### PR DESCRIPTION
There's a curl example at https://api.slack.com/web#basics (for chat.postMessage) where they POST JSON to the endpoint, so I tried that with chat.command, but it didn't work (I got back "error": "channel_not_found").

Not sure if only GET is supported, maybe POST and parameters presented as "application/x-www-form-urlencoded" works too, I haven't tried.

But hopefully this can help others to not make the same mistake as I did.